### PR TITLE
Add ability to set/replace the prompt

### DIFF
--- a/src/ecdc/ecdc.c
+++ b/src/ecdc/ecdc.c
@@ -836,7 +836,9 @@ ecdc_alloc_list_command(struct ecdc_console * console,
 }
 
 
-char const * ecdc_replace_prompt(struct ecdc_console *console, char const *prompt)
+char const * 
+ecdc_replace_prompt(struct ecdc_console *console, 
+                    char const *prompt)
 {
     if ((NULL == console) || (NULL == prompt))
     {
@@ -851,7 +853,8 @@ char const * ecdc_replace_prompt(struct ecdc_console *console, char const *promp
     return console->prompt;
 }
 
-void ecdc_free_prompt(struct ecdc_console *console)
+void 
+ecdc_free_prompt(struct ecdc_console *console)
 {
     free(console->prompt);
     console->prompt = NULL;

--- a/src/ecdc/ecdc.c
+++ b/src/ecdc/ecdc.c
@@ -35,7 +35,7 @@
 // in a standard, but we can assume that we won't have to process any of the
 // really complex ones. That is mostly the terminals problem
 #define CS_BUFFER_SIZE                  16
-
+#define DEFAULT_PROMPT                  " # "
 
 // -------------------------------------------------------------- Private types
 
@@ -94,8 +94,10 @@ struct ecdc_console {
     // Flags and settings
     bool                                f_local_echo;
     enum ecdc_mode                      mode;
-};
 
+    // Prompt
+    char  *                             prompt;
+};
 
 // ---------------------------------------------------------- Private functions
 
@@ -612,8 +614,15 @@ state_start_new_command(struct ecdc_console * console)
     }
 
     // Set new state to read user input
-    // TODO: Make the prompt configurable
-    term_puts(console, " # ");
+    if (NULL == console->prompt)
+    {
+        term_puts(console, DEFAULT_PROMPT);
+    }
+    else
+    {
+        term_puts(console, console->prompt);
+    }
+
     console->state = state_read_input;
 }
 
@@ -671,6 +680,7 @@ ecdc_alloc_console(void * console_hint,
     console->hint = console_hint;
     console->snoop_char = ECDC_GETC_EOF;
     console->state = state_wait_for_client;
+    console->prompt     = NULL;
 
     if(max_arg_line_length < 16) {
         max_arg_line_length = 16;
@@ -825,6 +835,26 @@ ecdc_alloc_list_command(struct ecdc_console * console,
 }
 
 
+char const * ecdc_replace_prompt(struct ecdc_console *console, char const *prompt)
+{
+    if ((NULL == console) || (NULL == prompt))
+    {
+        return NULL;
+    }
+
+    // If the prompt was previously not set, it will be NULL which will not
+    // have any ill side effects when calling free
+    free(console->prompt);
+
+    console->prompt = strdup(prompt);
+    return console->prompt;
+}
+
+void ecdc_free_prompt(struct ecdc_console *console)
+{
+    free(console->prompt);
+    console->prompt = NULL;
+}
 
 void
 ecdc_putc(struct ecdc_console * console, char c)

--- a/src/ecdc/ecdc.c
+++ b/src/ecdc/ecdc.c
@@ -747,6 +747,7 @@ ecdc_free_console(struct ecdc_console * console)
 
         free(console->argv);
         free(console->arg_line);
+        free(console->prompt);
         free(console);
     }
 }

--- a/src/ecdc/ecdc.h
+++ b/src/ecdc/ecdc.h
@@ -146,6 +146,32 @@ ecdc_configure_console(struct ecdc_console * console,
                        enum ecdc_mode mode,
                        int flags);
 
+/**
+ * @brief Replaces prompt
+ * @details This command will set the prompt or replaces it if previously set by user
+ * 
+ * @param ecdc_console Console to set prompt on
+ * @param prompt Pointer to C-string containing the desired prompt
+ * 
+ * @return Pointer to newly allocated prompt string.  It is the responsibility
+ *         of the user to deallocate this with the ecdc_free_prompt fucnction.  NULL
+ *         is returned on failure.
+ * 
+ */
+char const *
+ecdc_replace_prompt(struct ecdc_console *console, 
+                    char const *prompt);
+
+/**
+ * @brief Deallocated previously allocated prompt
+ * @details This will deallocate any resources allocated by the ecdc_set_prompt command
+ *          and resets prompt to default.
+ * 
+ * @param   ecdc_console Console for which to deallocate prompt
+ */
+void 
+ecdc_free_prompt(struct ecdc_console *console);
+
 
 // ------------------------------------------ Command allocation / deallocation
 
@@ -216,32 +242,6 @@ ecdc_free_command(struct ecdc_command * command);
 struct ecdc_command *
 ecdc_alloc_list_command(struct ecdc_console * console,
                         const char * command_name);
-
-/**
- * @brief Replaces prompt
- * @details This command will set the prompt or replaces it if previously set by user
- * 
- * @param ecdc_console Console to set prompt on
- * @param prompt Pointer to C-string containing the desired prompt
- * 
- * @return Pointer to newly allocated prompt string.  It is the responsibility
- *         of the user to deallocate this with the ecdc_free_prompt fucnction.  NULL
- *         is returned on failure.
- * 
- */
-char const *
-ecdc_replace_prompt(struct ecdc_console *console, 
-                    char const *prompt);
-
-/**
- * @brief Deallocated previously allocated prompt
- * @details This will deallocate any resources allocated by the ecdc_set_prompt command
- *          and resets prompt to default.
- * 
- * @param   ecdc_console Console for which to deallocate prompt
- */
-void 
-ecdc_free_prompt(struct ecdc_console *console);
 
 // --------------------------------------------------------------------- Extras
 

--- a/src/ecdc/ecdc.h
+++ b/src/ecdc/ecdc.h
@@ -229,7 +229,9 @@ ecdc_alloc_list_command(struct ecdc_console * console,
  *         is returned on failure.
  * 
  */
-char const *ecdc_replace_prompt(struct ecdc_console *console, char const *prompt);
+char const *
+ecdc_replace_prompt(struct ecdc_console *console, 
+                    char const *prompt);
 
 /**
  * @brief Deallocated previously allocated prompt
@@ -238,7 +240,8 @@ char const *ecdc_replace_prompt(struct ecdc_console *console, char const *prompt
  * 
  * @param   ecdc_console Console for which to deallocate prompt
  */
-void ecdc_free_prompt(struct ecdc_console *console);
+void 
+ecdc_free_prompt(struct ecdc_console *console);
 
 // --------------------------------------------------------------------- Extras
 

--- a/src/ecdc/ecdc.h
+++ b/src/ecdc/ecdc.h
@@ -217,6 +217,28 @@ struct ecdc_command *
 ecdc_alloc_list_command(struct ecdc_console * console,
                         const char * command_name);
 
+/**
+ * @brief Replaces prompt
+ * @details This command will set the prompt or replaces it if previously set by user
+ * 
+ * @param ecdc_console Console to set prompt on
+ * @param prompt Pointer to C-string containing the desired prompt
+ * 
+ * @return Pointer to newly allocated prompt string.  It is the responsibility
+ *         of the user to deallocate this with the ecdc_free_prompt fucnction.  NULL
+ *         is returned on failure.
+ * 
+ */
+char const *ecdc_replace_prompt(struct ecdc_console *console, char const *prompt);
+
+/**
+ * @brief Deallocated previously allocated prompt
+ * @details This will deallocate any resources allocated by the ecdc_set_prompt command
+ *          and resets prompt to default.
+ * 
+ * @param   ecdc_console Console for which to deallocate prompt
+ */
+void ecdc_free_prompt(struct ecdc_console *console);
 
 // --------------------------------------------------------------------- Extras
 


### PR DESCRIPTION
This PR adds the ability for the user to set the prompt.  If the prompt is not set or the user un-sets it, the default prompt will be used instead.